### PR TITLE
Add sticky navigation and semantic publication headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,354 +1,367 @@
 <!DOCTYPE HTML>
-<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-EWSWCE7MTD"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-EWSWCE7MTD"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-  gtag('config', 'G-EWSWCE7MTD');
-</script>
+    gtag('config', 'G-EWSWCE7MTD');
+  </script>
 
   <title>Zhongzhi Yu – Research Scientist (LLMs, Efficient DL)</title>
-  <meta name="description" content="Zhongzhi Yu—Research Scientist at NVIDIA; Ph.D. (Georgia Tech). Efficient LLM inference/tuning, transformer adaptation, and LLM-for-hardware. Publications, CV, and contact." />
+  <meta name="description" content="Zhongzhi Yu—Research Scientist at NVIDIA; Ph.D. (Georgia Tech). Efficient LLM inference/tuning, transformer adaptation, and LLM-for-hardware. Publications, CV, and contact.">
   <meta name="keywords" content="Zhongzhi Yu, Research Scientist, NVIDIA, LLM, Efficient Deep Learning, Georgia Tech, Large Language Models, Transformer, AI, Machine Learning">
   <link rel="canonical" href="https://yuzz1020.github.io/" />
-  <meta name="robots" content="index,follow" />  
-  
+  <meta name="robots" content="index,follow" />
+
   <meta name="author" content="Zhongzhi Yu">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
+
   <link rel="stylesheet" type="text/css" href="stylesheet.css">
   <link rel="icon" type="image/png" href="images/gt_seal.png">
-  
+
   <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Person",
-  "name": "Zhongzhi Yu",
-  "alternateName": ["Dr. Zhongzhi Yu", "Zhongzhi Yu NVIDIA", "Zhongzhi Yu Georgia Tech"],
-  "affiliation": {
-    "@type": "Organization",
-    "name": "NVIDIA Research"
-  },
-  "alumniOf": [
-    {
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Zhongzhi Yu",
+    "alternateName": ["Dr. Zhongzhi Yu", "Zhongzhi Yu NVIDIA", "Zhongzhi Yu Georgia Tech"],
+    "affiliation": {
       "@type": "Organization",
-      "name": "Georgia Institute of Technology"
+      "name": "NVIDIA Research"
     },
-    {
-      "@type": "Organization", 
-      "name": "Columbia University"
-    },
-    {
-      "@type": "Organization",
-      "name": "Zhejiang University"
-    }
-  ],
-  "jobTitle": "Research Scientist",
-  "description": "Research Scientist at NVIDIA specializing in Large Language Models (LLMs), Efficient Deep Learning, and AI Accelerator Design",
-  "knowsAbout": ["Large Language Models", "Efficient Deep Learning", "Transformer Models", "AI Accelerators", "Computer Vision"],
-  "url": "https://yuzz1020.github.io/",
-  "sameAs": [
-    "https://scholar.google.com/citations?user=KjvcaBQAAAAJ",
-    "https://www.linkedin.com/in/zhongzhi-yu/",
-    "https://github.com/Yuzz1020"
-  ],
-  "email": "mailto:zyu401@gatech.edu"
-}
-</script>
+    "alumniOf": [
+      {
+        "@type": "Organization",
+        "name": "Georgia Institute of Technology"
+      },
+      {
+        "@type": "Organization",
+        "name": "Columbia University"
+      },
+      {
+        "@type": "Organization",
+        "name": "Zhejiang University"
+      }
+    ],
+    "jobTitle": "Research Scientist",
+    "description": "Research Scientist at NVIDIA specializing in Large Language Models (LLMs), Efficient Deep Learning, and AI Accelerator Design",
+    "knowsAbout": ["Large Language Models", "Efficient Deep Learning", "Transformer Models", "AI Accelerators", "Computer Vision"],
+    "url": "https://yuzz1020.github.io/",
+    "sameAs": [
+      "https://scholar.google.com/citations?user=KjvcaBQAAAAJ",
+      "https://www.linkedin.com/in/zhongzhi-yu/",
+      "https://github.com/Yuzz1020"
+    ],
+    "email": "mailto:zyu401@gatech.edu"
+  }
+  </script>
 </head>
 
 <body>
-  <table style="width:100%;max-width:950px;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-    <tr style="padding:0px">
-      <td style="padding:0px">
-        <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-          <tr style="padding:0px">
-            <td style="padding:2.5%;width:67%;vertical-align:middle">
-              <h1 style="text-align:center;margin:0;font-size:2.5em;font-weight:400;">
-                Zhongzhi Yu
-              </h1>
-              <h2 style="text-align:center;margin:0.5em 0;font-size:1.2em;font-weight:300;color:#666;">
-                Research Scientist at NVIDIA
-              </h2>
-              
-              <p>I am a Research Scientist at NVIDIA Research, specializing in efficient deep learning algorithms for large language models (LLMs). Zhongzhi Yu obtained his Ph.D. in Computer Science from Georgia Tech, where he was advised by <a href="https://eiclab.scs.gatech.edu/pages/team.html">Prof. Yingyan (Celine) Lin</a>. My research interests lie in efficient deep learning algorithms, with a focus on designing efficient inference and tuning methods for large-scale transformer models. Additionally, I work on enabling the effective adaptation of transformer models to downstream tasks in data-scarce scenarios.</p>
-              
-              <p>Before pursuing his Ph.D., Zhongzhi Yu received an M.S. from Columbia University and a B.Eng. from Zhejiang University.</p>
-              
-              <p>I am currently interning at Nvidia Research as a research intern, where I am fortunate to work with <a href="https://research.nvidia.com/person/haoxing-mark-ren">Dr. Mark Ren</a> and <a href="https://research.nvidia.com/person/mingjie-liu">Dr. Mingjie Liu</a>. Before that, I interned as a research intern at MIT-IBM Watson AI Lab during 2021, where I was fortunate to work with <a href="https://mitibmwatsonailab.mit.edu/people/yang-zhang/">Dr. Yang Zhang</a> and <a href="https://www.linkedin.com/in/kaizhi-qian-4228ba6a/">Dr. Kaizhi Qian</a>.</p>
-              
-              <p style="text-align:center">
-              	<a href="mailto:zyu401@gatech.edu">Email</a> &nbsp/&nbsp
-                <a href="https://scholar.google.com/citations?user=KjvcaBQAAAAJ&hl=en">Google Scholar</a> &nbsp/&nbsp
-                <a href="data/Zhongzhi_Yu_CV.pdf">CV</a> &nbsp/&nbsp
-                <a href="https://www.linkedin.com/in/zhongzhi-yu/">LinkedIn</a> &nbsp/&nbsp
-                <a href="https://github.com/Yuzz1020">GitHub</a>
-              </p><br>
-            </td>
-            <td style="padding:2.5%;width:40%;max-width:40%">
-              <a href="data/Zhongzhi_Img.jpg"><img style="width:100%;max-width:100%;object-fit: cover; border-radius: 50%;" alt="Zhongzhi Yu - Research Scientist at NVIDIA" src="data/Zhongzhi_Img.jpg" class="hoverZoomLink"></a>
-            </td>
-          </tr>
-          
-          <table style="width:101%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-              <tr>
-              <td style="padding:20px;width:100%;vertical-align:middle">
-                <h2 style="margin:0;">News</h2>  
-                <div style="height:200px;overflow-y:auto">
-                <p></p><ul>
-                <li> [Jun. 2024] <b style="color:#002df8;">[Award]</b> Our work <a href="https://arxiv.org/pdf/2407.01910"><papertitle>MG-Verilog: Multi-grained Dataset Towards Enhanced LLM-assisted Verilog Generation</papertitle></a> received the best paper award in <strong>first IEEE International Workshop on LLM-Aided Design (LAD 2024)</strong>.</li>
-                <li> [May. 2024] <b style="color:#3EA055;">[Paper]</b> Our work <a href="https://arxiv.org/pdf/2406.15765"><papertitle>Unveiling and Harnessing Hidden Attention Sinks: Enhancing Large Language Models without Training through Attention Calibration</papertitle></a> is accepted by <strong>ICML 2024</strong>.</li>
-                <li> [Feb. 2024] <b style="color:#3EA055;">[Paper]</b> Our work <a href="https://arxiv.org/pdf/2406.15758"><papertitle>EDGE-LLM: Enabling Efficient Large Language Model Adaptation on Edge Devices via Layerwise Unified Compression and Adaptive Layer Tuning and Voting</papertitle></a> is accepted by <strong>DAC 2024</strong>.</li>
-                <li> [Jul. 2023] <b style="color:#3EA055;">[Paper]</b> Our work <a href="https://arxiv.org/pdf/2309.10730.pdf"><papertitle>GPT4AIGChip: Towards Next-Generation AI Accelerator Design Automation via Large Language Models</papertitle></a> is accepted by <strong>ICCAD 2023</strong>.</li>
-                <li> [Jul. 2023] <b style="color:#002df8;">[Award]</b> Our Demo <papertitle>Gen-NeRF: Efficient and Generalizable Neural Radiance Fields via Algorithm-Hardware Co-Design</papertitle> is awarded 2nd Place on University Demo Best Demonstration Award <strong>at DAC 2023</strong>.</li>
-                <li> [Apr. 2023] <b style="color:#3EA055;">[Paper]</b> Our work <a href="https://arxiv.org/abs/2306.15686"><papertitle>Master-ASR: Achieving Multilingual Scalability and Low-Resource Adaptation in ASR with Modularized Learning</papertitle></a> is accepted by <strong>ICML 2023</strong>.</li>
-                <li> [Feb. 2023] <b style="color:#3EA055;">[Paper]</b> Our work <a href="https://openaccess.thecvf.com/content/CVPR2023/papers/Yu_Hint-Aug_Drawing_Hints_From_Foundation_Vision_Transformers_Towards_Boosted_Few-Shot_CVPR_2023_paper.pdf"><papertitle>Hint-Aug: Drawing Hints from Vision Foundation Models towards Boosted Few-shot Parameter-Efficient ViT Tuning</papertitle></a> is accepted by <strong>CVPR 2023</strong>.</li>
-                <li> [Feb. 2023] <b style="color:#3EA055;">[Paper]</b> Our work <a href="https://arxiv.org/pdf/2306.13586.pdf"><papertitle>NetBooster: Empowering Tiny Deep Learning By Standing on the Shoulders of Deep Giants</papertitle></a> is accepted by <strong>DAC 2023</strong>.</li>
-              </ul>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" id="top">
+    <div class="top-nav" role="navigation" aria-label="Primary">
+      <div class="nav-wrapper">
+        <div class="brand">ZY</div>
+        <nav class="site-nav" aria-label="Primary">
+          <a href="#news">News</a>
+          <a href="#research">Research</a>
+          <a href="#publications">Publications</a>
+          <a href="#service">Service</a>
+          <a href="data/Zhongzhi_Yu_CV.pdf" class="nav-cta" target="_blank" rel="noopener">CV</a>
+        </nav>
+      </div>
+    </div>
+    <div class="hero container">
+      <div class="hero-text">
+        <p class="eyebrow">Research Scientist @ NVIDIA</p>
+        <h1>Zhongzhi Yu</h1>
+        <p class="lead">
+          I design efficient learning algorithms for large language models, with a focus on inference calibration,
+          adaptive tuning, and human-in-the-loop hardware design. My work bridges LLM foundations with practical
+          deployment on data- and compute-constrained platforms.
+        </p>
+        <div class="hero-tags" role="list">
+          <span class="tag" role="listitem">LLM Efficiency</span>
+          <span class="tag" role="listitem">Attention Calibration</span>
+          <span class="tag" role="listitem">LLM-for-Hardware</span>
+        </div>
+        <div class="hero-links" aria-label="Primary contact links">
+          <a href="mailto:zyu401@gatech.edu" class="button">Email</a>
+          <a href="https://scholar.google.com/citations?user=KjvcaBQAAAAJ&hl=en" class="button ghost" target="_blank" rel="noopener">Google Scholar</a>
+          <a href="https://www.linkedin.com/in/zhongzhi-yu/" class="button ghost" target="_blank" rel="noopener">LinkedIn</a>
+          <a href="https://github.com/Yuzz1020" class="button ghost" target="_blank" rel="noopener">GitHub</a>
+        </div>
+        <p class="current-work">
+          Currently, I'm exploring on-the-fly inference upgrades for foundation models and co-designing AI accelerators with LLM assistance.
+        </p>
+      </div>
+      <div class="hero-image">
+        <figure>
+          <img src="data/Zhongzhi_Img.jpg" alt="Portrait of Zhongzhi Yu" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section" id="news">
+      <div class="container">
+        <header class="section-header">
+          <h2>News & Highlights</h2>
+          <p>Recent milestones, publications, and recognitions.</p>
+        </header>
+        <div class="news-timeline" role="feed">
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Jun 2024</span>
+              <span class="badge award">Award</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://arxiv.org/pdf/2407.01910" target="_blank" rel="noopener">MG-Verilog: Multi-grained Dataset Towards Enhanced LLM-assisted Verilog Generation</a></h3>
+              <p>Received the Best Paper Award at the inaugural IEEE LAD 2024 workshop on LLM-Aided Design.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">May 2024</span>
+              <span class="badge publication">Paper</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://arxiv.org/pdf/2406.15765" target="_blank" rel="noopener">Unveiling and Harnessing Hidden Attention Sinks</a></h3>
+              <p>Our attention calibration framework for LLMs has been accepted to ICML 2024.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Feb 2024</span>
+              <span class="badge publication">Paper</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://arxiv.org/pdf/2406.15758" target="_blank" rel="noopener">EDGE-LLM</a></h3>
+              <p>Layer-wise compression and adaptive tuning techniques for on-device LLM adaptation accepted by DAC 2024.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Jul 2023</span>
+              <span class="badge publication">Paper</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://arxiv.org/pdf/2309.10730.pdf" target="_blank" rel="noopener">GPT4AIGChip</a></h3>
+              <p>Our LLM-driven accelerator design framework has been accepted by ICCAD 2023.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Jul 2023</span>
+              <span class="badge award">Award</span>
+            </div>
+            <div class="news-content">
+              <h3>Gen-NeRF Demo</h3>
+              <p>Won 2nd place in the University Demo Best Demonstration Award at DAC 2023.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Apr 2023</span>
+              <span class="badge publication">Paper</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://arxiv.org/abs/2306.15686" target="_blank" rel="noopener">Master-ASR</a></h3>
+              <p>Modularized multilingual ASR system accepted by ICML 2023.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Feb 2023</span>
+              <span class="badge publication">Paper</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://openaccess.thecvf.com/content/CVPR2023/papers/Yu_Hint-Aug_Drawing_Hints_From_Foundation_Vision_Transformers_Towards_Boosted_Few-Shot_CVPR_2023_paper.pdf" target="_blank" rel="noopener">Hint-Aug</a></h3>
+              <p>Few-shot ViT tuning framework accepted by CVPR 2023.</p>
+            </div>
+          </article>
+          <article class="news-item" role="article">
+            <div class="news-meta">
+              <span class="news-date">Feb 2023</span>
+              <span class="badge publication">Paper</span>
+            </div>
+            <div class="news-content">
+              <h3><a href="https://arxiv.org/pdf/2306.13586.pdf" target="_blank" rel="noopener">NetBooster</a></h3>
+              <p>Efficiency boosting framework for tiny neural networks accepted by DAC 2023.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section surface" id="research">
+      <div class="container research-section">
+        <header class="section-header">
+          <h2>Research Focus</h2>
+        </header>
+        <div class="research-content">
+          <p>
+            I study how to make large language models adaptable, efficient, and dependable in real-world settings.
+            My research spans three pillars:
+          </p>
+          <ul>
+            <li><strong>Inference Calibration:</strong> Elevating LLM outputs with lightweight attention refinements and dynamic evaluation strategies.</li>
+            <li><strong>Adaptive Tuning:</strong> Designing compression-aware fine-tuning and voting schemes so edge devices can host powerful LLM experiences.</li>
+            <li><strong>LLM-for-Hardware:</strong> Co-designing silicon and software by steering LLMs to generate and verify hardware designs with human-centered workflows.</li>
+          </ul>
+          <p>
+            Previously, I earned my Ph.D. in Computer Science from Georgia Tech, advised by
+            <a href="https://eiclab.scs.gatech.edu/pages/team.html" target="_blank" rel="noopener">Prof. Yingyan (Celine) Lin</a>.
+            I also hold an M.S. from Columbia University and a B.Eng. from Zhejiang University, and I have collaborated with MIT-IBM Watson AI Lab.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="publications">
+      <div class="container">
+        <header class="section-header">
+          <h2>Selected Publications</h2>
+          <p class="subtitle">* denotes equal contribution</p>
+        </header>
+        <div class="publication-grid">
+          <article class="publication-card">
+            <img src="images/act.png" alt="Visualization for attention calibration technique">
+            <div class="card-body">
+              <h3 class="paper-title">Unveiling and Harnessing Hidden Attention Sinks: Enhancing Large Language Models without Training through Attention Calibration</h3>
+              <p class="authors">Zhongzhi Yu, Zheng Wang, Yonggan Fu, Huihong Shi, Khalid Shaikh, Yingyan (Celine) Lin</p>
+              <p class="description">A systematic study of attention sink behaviors in LLMs paired with an inference-time calibration method.</p>
+              <a href="https://arxiv.org/pdf/2406.15765" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/edge-llm.gif" alt="Visualization for EDGE-LLM">
+            <div class="card-body">
+              <h3 class="paper-title">EDGE-LLM: Enabling Efficient Large Language Model Adaptation on Edge Devices via Layerwise Unified Compression and Adaptive Layer Tuning and Voting</h3>
+              <p class="authors">Zhongzhi Yu, Zheng Wang, Yuhan Li, Haoran You, Ruijie Gao, Xiaoya Zhou, Sreenidhi Reedy Bommu, Yang (Katie) Zhao, Yingyan (Celine) Lin</p>
+              <p class="description">Compression-aware fine-tuning that unlocks on-device LLM adaptation with minimal hardware overhead.</p>
+              <a href="https://arxiv.org/pdf/2406.15758" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/mg-verilog.png" alt="Visualization for MG-Verilog dataset">
+            <div class="card-body">
+              <h3 class="paper-title">MG-Verilog: Multi-grained Dataset Towards Enhanced LLM-assisted Verilog Generation</h3>
+              <p class="authors">Yongan Zhang, Zhongzhi Yu, Yonggan Fu, Cheng Wan, Yingyan (Celine) Lin</p>
+              <p class="description">The first multi-granularity Verilog dataset enabling precise LLM-guided hardware code generation.</p>
+              <a href="https://arxiv.org/pdf/2407.01910.pdf" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/GPT4AIGchip.png" alt="Visualization for GPT4AIGChip framework">
+            <div class="card-body">
+              <h3 class="paper-title">GPT4AIGChip: Towards Next-Generation AI Accelerator Design Automation via Large Language Models</h3>
+              <p class="authors">Yonggan Fu*, Yongan Zhang*, Zhongzhi Yu*, Sixu Li, Zhifan Ye, Chaojian Li, Cheng Wan, Yingyan (Celine) Lin</p>
+              <p class="description">Human-in-the-loop workflows that translate natural language into accelerator design artifacts.</p>
+              <a href="https://arxiv.org/pdf/2309.10730.pdf" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/master_asr.png" alt="Visualization for Master-ASR framework">
+            <div class="card-body">
+              <h3 class="paper-title">Master-ASR: Achieving Multilingual Scalability and Low-Resource Adaptation in ASR with Modularized Learning</h3>
+              <p class="authors">Zhongzhi Yu, Yang Zhang, Kaizhi Qian, Cheng Wan, Yonggan Fu, Yongan Zhang, Yingyan (Celine) Lin</p>
+              <p class="description">A modular ASR architecture that balances multilingual performance and low-resource specialization.</p>
+              <a href="https://arxiv.org/abs/2306.15686" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/Hint-Aug.png" alt="Visualization for Hint-Aug">
+            <div class="card-body">
+              <h3 class="paper-title">Hint-Aug: Drawing Hints from Vision Foundation Models towards Boosted Few-shot Parameter-Efficient ViT Tuning</h3>
+              <p class="authors">Zhongzhi Yu, Shang Wu, Yonggan Fu, Cheng Wan, Shunyao Zhang, Chaojian Li, Yingyan (Celine) Lin</p>
+              <p class="description">Integrating attention-aware data augmentation to amplify few-shot ViT tuning effectiveness.</p>
+              <a href="https://openaccess.thecvf.com/content/CVPR2023/papers/Yu_Hint-Aug_Drawing_Hints_From_Foundation_Vision_Transformers_Towards_Boosted_Few-Shot_CVPR_2023_paper.pdf" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/netbooster.png" alt="Visualization for NetBooster">
+            <div class="card-body">
+              <h3 class="paper-title">NetBooster: Empowering Tiny Deep Learning By Standing on the Shoulders of Deep Giants</h3>
+              <p class="authors">Zhongzhi Yu, Yonggan Fu, Jiayi Yuan, Haoran You, Yingyan (Celine) Lin</p>
+              <p class="description">A blueprint for uplifting compact neural networks via expansion-then-contraction strategies.</p>
+              <a href="https://arxiv.org/pdf/2306.13586.pdf" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/eyecod_tp.png" alt="Visualization for EyeCoD system">
+            <div class="card-body">
+              <h3 class="paper-title">EyeCoD: Eye Tracking System Acceleration via FlatCam-based Algorithm/Hardware Co-Design</h3>
+              <p class="authors">Haoran You*, Cheng Wan*, Yang Zhao*, Zhongzhi Yu*, Yonggan Fu, Jiayi Yuan, Shang Wu, Shunyao Zhang, Yongan Zhang, Chaojian Li, Vivek Boominathan, Ashok Veeraraghavan, Ziyun Li, Yingyan (Celine) Lin</p>
+              <p class="description">A compact lensless eye-tracking system achieving high throughput through algorithm-hardware co-design.</p>
+              <a href="https://ieeexplore.ieee.org/document/10123119" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/AugViT-1.png" alt="Visualization for AugViT">
+            <div class="card-body">
+              <h3 class="paper-title">AugViT: Improving Vision Transformer Training by Marrying Attention and Data Augmentation</h3>
+              <p class="authors">Zhongzhi Yu, Yonggan Fu, Chaojian Li, Yingyan (Celine) Lin</p>
+              <p class="description">An attention-aware augmentation framework that consistently lifts ViT accuracy across hardware tiers.</p>
+              <a href="https://ieeexplore.ieee.org/document/10123119" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/miaformer.png" alt="Visualization for MIA-Former">
+            <div class="card-body">
+              <h3 class="paper-title">MIA-Former: Efficient and Robust Vision Transformers via Multi-grained Input-Adaptation</h3>
+              <p class="authors">Zhongzhi Yu, Yonggan Fu, Sicheng Li, Mengquan Li, Chaojian Li, Yingyan (Celine) Lin</p>
+              <p class="description">A multi-grained input-adaptive ViT that dynamically adjusts depth, heads, and tokens.</p>
+              <a href="https://www.aaai.org/AAAI22Papers/AAAI-4994.YuZ.pdf" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+          <article class="publication-card">
+            <img src="images/LDP.png" alt="Visualization for LDP framework">
+            <div class="card-body">
+              <h3 class="paper-title">LDP: Learnable Dynamic Precision for Efficient Deep Neural Network Training and Inference</h3>
+              <p class="authors">Zhongzhi Yu, Yonggan Fu, Shang Wu, Mengquan Li, Haoran You, Yingyan Lin</p>
+              <p class="description">Temporal and spatial precision scheduling for DNN training that optimizes accuracy-efficiency trade-offs.</p>
+              <a href="https://arxiv.org/abs/2203.07713" target="_blank" rel="noopener" class="card-link">Paper</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section surface" id="service">
+      <div class="container">
+        <header class="section-header">
+          <h2>Academic Service</h2>
+        </header>
+        <div class="service-list">
+          <div class="service-card">
+            <h3>Conference Reviewer</h3>
+            <p>ICLR 2023, NeurIPS 2022–2023, ICML 2023, CVPR 2023, AAAI 2022, AICAS 2022.</p>
           </div>
-              </td>
-            </tr>
-          </tbody></table>
-          
-          <table style="width:101%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-              <tr>
-              <td style="padding:20px;width:100%;vertical-align:middle">
-                <h2 style="margin:0;">Research Interests</h2>  
-                <p></p>
-                <p>Zhongzhi Yu's research interests lie in developing efficient deep learning algorithms, particularly in creating effective inference and tuning methods for large-scale transformer models to further optimize their achievable accuracy-efficiency trade-off. Recently, I have also been interested in designing data-efficient techniques to enable large language models to generate hardware designs, including but not limited to hardware code, aiming to alleviate the tedious manpower involved in the hardware design process.</p>
-              </td>
-            </tr>
-          </tbody></table>
-          <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
+          <div class="service-card">
+            <h3>Artifact Evaluation</h3>
+            <p>MICRO 2023 Artifact Evaluation Committee.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
 
-
-        </tbody></table>
-       
-        <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-            <tr>
-            <td style="padding:20px;width:100%;vertical-align:middle">
-              <h2 style="margin:0;">Selected Publications</h2><span style="font-size:0.9em;"> &nbsp &nbsp &nbsp (*: Equal Contributions)</span>
-            </td> 
-          </tr> 
-        </tbody></table> 
-        <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-
-          
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/act.png" alt="Attention Calibration Technique by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>Unveiling and Harnessing Hidden Attention Sinks: Enhancing Large Language Models without Training through Attention Calibration</papertitle>
-              <br>
-              Zhongzhi Yu, Zheng Wang, Yonggan Fu, Huihong Shi, Khalid Shaikh, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://arxiv.org/pdf/2406.15765">Paper</a> 
-              <br>
-              <p></p>
-              <p>We conduct a comprehensive exploration of the attention sink mechanism in LLMs and propose an attention calibration technique to improve their performance on-the-fly during inference.</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/edge-llm.gif" alt="EDGE-LLM by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>EDGE-LLM: Enabling Efficient Large Language Model Adaptation on Edge Devices via Layerwise Unified Compression and Adaptive Layer Tuning and Voting</papertitle>
-              <br>
-              Zhongzhi Yu, Zheng Wang, Yuhan Li, Haoran You, Ruijie Gao, Xiaoya Zhou, Sreenidhi Reedy Bommu, Yang (Katie) Zhao, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://arxiv.org/pdf/2406.15758">Paper</a> 
-              <br>
-              <p></p>
-              <p>We developed Edge-LLM, a computation- and memory-efficient tuning framework that enables on-device tuning of LLMs.</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/mg-verilog.png" alt="MG-Verilog by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>MG-Verilog: Multi-grained Dataset Towards Enhanced LLM-assisted Verilog Generation</papertitle>
-              <br>
-              Yongan Zhang, Zhongzhi Yu, Yonggan Fu, Cheng Wan, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://arxiv.org/pdf/2407.01910.pdf">Paper</a> 
-              <br>
-              <p></p>
-              <p>We release MG-Verilog, the first-of-its-kind Verilog code generation dataset with labels of multiple granularities.</p>
-            </td>
-          </tr> 
-          
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/GPT4AIGchip.png" alt="GPT4AIGChip by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>GPT4AIGChip: Towards Next-Generation AI Accelerator Design Automation via Large Language Models</papertitle>
-              <br>
-              Yonggan Fu*, Yongan Zhang*, Zhongzhi Yu*, Sixu Li, Zhifan Ye, Chaojian Li, Cheng Wan, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://arxiv.org/pdf/2309.10730.pdf">Paper</a> 
-              <br>
-              <p></p>
-              <p>We develop GPT4AIGChip, a framework intended to democratize AI accelerator design by leveraging human natural languages instead of domain-specific languages.</p>
-            </td>
-          </tr> 
-          
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/master_asr.png" alt="Master-ASR by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>Master-ASR: Achieving Multilingual Scalability and Low-Resource Adaptation in ASR with Modularized Learning</papertitle>
-              <br>
-              Zhongzhi Yu, Yang Zhang, Kaizhi Qian, Cheng Wan, Yonggan Fu, Yongan Zhang, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://arxiv.org/abs/2306.15686">Paper</a> 
-              <br>
-              <p></p>
-              <p>We propose an ASR framework, dubbed Master-ASR, that, for the first time, simultaneously achieves strong multilingual scalability and low-resource adaptation ability in a modularized-then-assemble manner.</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/Hint-Aug.png" alt="Hint-Aug by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>Hint-Aug: Drawing Hints from Vision Foundation Models towards Boosted Few-shot Parameter-Efficient ViT Tuning</papertitle>
-              <br>
-              Zhongzhi Yu, Shang Wu, Yonggan Fu, Cheng Wan, Shunyao Zhang, Chaojian Li, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://openaccess.thecvf.com/content/CVPR2023/papers/Yu_Hint-Aug_Drawing_Hints_From_Foundation_Vision_Transformers_Towards_Boosted_Few-Shot_CVPR_2023_paper.pdf">Paper</a> 
-              <br>
-              <p></p>
-              <p>We propose a framework called Hint-based Data Augmentation (Hint-Aug), which is dedicated to boosting the effectiveness of few-shot tuning foundation ViT models.</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/netbooster.png" alt="NetBooster by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>NetBooster: Empowering Tiny Deep Learning By Standing on the Shoulders of Deep Giants</papertitle>
-              <br>
-              Zhongzhi Yu, Yonggan Fu, Jiayi Yuan, Haoran You, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://arxiv.org/pdf/2306.13586.pdf">Paper</a> 
-              <br>
-              <p></p>
-              <p>We propose a framework called NetBooster to empower tiny deep learning by augmenting the architectures of TNNs via an expansion-then-contraction strategy.</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/eyecod_tp.png" alt="EyeCoD by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>EyeCoD: Eye Tracking System Acceleration via FlatCam-based Algorithm/Hardware Co-Design</papertitle>
-              <br>
-              Haoran You*, Cheng Wan*, Yang Zhao*, Zhongzhi Yu*, Yonggan Fu, Jiayi Yuan, Shang Wu, Shunyao Zhang, Yongan Zhang, Chaojian Li, Vivek Boominathan, Ashok Veeraraghavan, Ziyun Li, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://ieeexplore.ieee.org/document/10123119">Paper</a> 
-              <br>
-              <p></p>
-              <p>We devise a lensless FlatCam-based eye tracking algorithm and hardware accelerator co-design framework dubbed EyeCoD, which is the first system to meet the high throughput requirement with smaller form-factor.</p>
-            </td>
-          </tr> 
-          
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/AugViT-1.png" alt="AugViT by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>AugViT: Improving Vision Transformer Training by Marrying Attention and Data Augmentation</papertitle>
-              <br>
-              Zhongzhi Yu, Yonggan Fu, Chaojian Li, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://ieeexplore.ieee.org/document/10123119">Paper</a> 
-              <br>
-              <p></p>
-              <p>We propose a data augmentation framework called AugViT, which is dedicated to incorporating the key component in ViTs, i.e., self-attention, into data augmentation intensity to enable ViT's outstanding accuracy across various devices.</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/miaformer.png" alt="MIA-Former by Zhongzhi Yu" width="150" height="150">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>MIA-Former: Efficient and Robust Vision Transformers via Multi-grained Input-Adaptation</papertitle>
-              <br>
-              Zhongzhi Yu, Yonggan Fu, Sicheng Li, Mengquan Li, Chaojian Li, and Yingyan (Celine) Lin
-              <br>
-              <a href="https://www.aaai.org/AAAI22Papers/AAAI-4994.YuZ.pdf">Paper</a> 
-              <br>
-              <p></p>
-              <p>We propose a Multi-grained Input-Adaptive Vision Transformer framework dubbed MIA-Former that can input-adaptively adjust the structure of ViTs at three coarse-to-fine-grained granularities (i.e., model depth and the number of model heads/tokens).</p>
-            </td>
-          </tr> 
-
-          <tr>
-            <td style="padding:20px;width:25%;vertical-align:middle">
-              <img src="images/LDP.png" alt="LDP by Zhongzhi Yu" width="160" height="160">
-              </td>
-            <td style="padding:20px;width:75%;vertical-align:middle">
-                <papertitle>LDP: Learnable Dynamic Precision for Efficient Deep Neural Network Training and Inference</papertitle>
-              <br>
-              Zhongzhi Yu, Yonggan Fu, Shang Wu, Mengquan Li, Haoran You, and Yingyan Lin
-              <br>
-              <a href="https://arxiv.org/abs/2203.07713">Paper</a> 
-              <br>
-              <p></p>
-              <p>We propose LDP, a Learnable Dynamic Precision DNN training framework that can automatically learn a temporally and spatially dynamic precision schedule during training towards optimal accuracy and efficiency trade-offs.</p>
-            </td>
-          </tr> 
-
-          </tbody>
-          </table>
-          
-          <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-
-
-        </tbody></table>
-
-          <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-            <tr>
-            <td style="padding:20px;width:100%;vertical-align:middle">
-              <h2 style="margin:0;">Academic Service</h2>  
- 				<p></p><ul>
- 				<li> Conference Reviewer: ICLR'23, NeurIPS'23, ICML'23, CVPR'23, AAAI'22, NeurIPS'22, AICAS'22.</li>
- 				<li> Artifact Evaluation Committee: MICRO'23.</li>
-   				</ul>
-              </td>
-            </tr>
-          </tbody></table>
-          <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-    
-        <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
-          <tr>
-            <td style="padding:0px">
-              <br>
-              <p style="text-align:right;font-size:small;">
-                Last Update: Dec. 2024
-                <br><br>
-                <a href="https://github.com/jonbarron/website">Website Template</a>
-                </p>
-            </td>
-          </tr>
-        </tbody></table>
-      </td>
-    </tr>
-  </table>
+  <footer class="site-footer">
+    <div class="container footer-content">
+      <p>Last updated: Dec 2024</p>
+      <div class="footer-links">
+        <a href="#top">Back to top</a>
+        <a href="https://github.com/jonbarron/website" target="_blank" rel="noopener">Original Template</a>
+      </div>
+    </div>
+  </footer>
 </body>
-
 </html>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,131 +1,519 @@
-/* latin-ext */
-@font-face {
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Lato Italic'), local('Lato-Italic'), url(https://fonts.gstatic.com/s/lato/v15/S6u8w4BMUTPHjxsAUi-qNiXg7eU0.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-/* latin */
-@font-face {
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Lato Italic'), local('Lato-Italic'), url(https://fonts.gstatic.com/s/lato/v15/S6u8w4BMUTPHjxsAXC-qNiXg7Q.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-/* latin-ext */
-@font-face {
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Lato Bold Italic'), local('Lato-BoldItalic'), url(https://fonts.gstatic.com/s/lato/v15/S6u_w4BMUTPHjxsI5wq_FQftx9897sxZ.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-/* latin */
-@font-face {
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Lato Bold Italic'), local('Lato-BoldItalic'), url(https://fonts.gstatic.com/s/lato/v15/S6u_w4BMUTPHjxsI5wq_Gwftx9897g.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-/* latin-ext */
+/* Typography */
 @font-face {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 400;
   src: local('Lato Regular'), local('Lato-Regular'), url(https://fonts.gstatic.com/s/lato/v15/S6uyw4BMUTPHjxAwXiWtFCfQ7A.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
-/* latin */
-@font-face {
-  font-family: 'Lato';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Lato Regular'), local('Lato-Regular'), url(https://fonts.gstatic.com/s/lato/v15/S6uyw4BMUTPHjx4wXiWtFCc.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-/* latin-ext */
+
 @font-face {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 700;
   src: local('Lato Bold'), local('Lato-Bold'), url(https://fonts.gstatic.com/s/lato/v15/S6u9w4BMUTPHh6UVSwaPGQ3q5d0N7w.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
-/* latin */
+
 @font-face {
   font-family: 'Lato';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Lato Bold'), local('Lato-Bold'), url(https://fonts.gstatic.com/s/lato/v15/S6u9w4BMUTPHh6UVSwiPGQ3q5d0.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-style: italic;
+  font-weight: 400;
+  src: local('Lato Italic'), local('Lato-Italic'), url(https://fonts.gstatic.com/s/lato/v15/S6u8w4BMUTPHjxsAXC-qNiXg7Q.woff2) format('woff2');
 }
 
-a {
-  color: #1772d0;
-  text-decoration: none;
+:root {
+  color-scheme: dark;
+  --bg: #020617;
+  --bg-accent: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.16), transparent 60%);
+  --surface: rgba(15, 23, 42, 0.82);
+  --surface-muted: rgba(15, 23, 42, 0.65);
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #60a5fa;
+  --accent-strong: #38bdf8;
+  --badge-award: #fbbf24;
+  --badge-paper: #34d399;
+  --border: rgba(148, 163, 184, 0.18);
+  --shadow: 0 18px 60px rgba(2, 6, 23, 0.45);
 }
 
-a:focus,
-a:hover {
-  color: #f09228;
-  text-decoration: none;
+* {
+  box-sizing: border-box;
 }
 
-body,
-td,
-th,
-tr,
-p,
-a {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 14px
+html {
+  scroll-behavior: smooth;
 }
 
-strong {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 14px;
+body {
+  margin: 0;
+  font-family: 'Lato', 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  background: var(--bg);
+  background-image: var(--bg-accent);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
 }
 
-heading {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 22px;
-}
-
-papertitle {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 14px;
-  font-weight: 700
-}
-
-name {
-  font-family: 'Lato', Verdana, Helvetica, sans-serif;
-  font-size: 32px;
-}
-
-.one {
-  width: 160px;
-  height: 160px;
-  position: relative;
-}
-
-.two {
-  width: 160px;
-  height: 160px;
+.skip-link {
   position: absolute;
-  transition: opacity .2s ease-in-out;
-  -moz-transition: opacity .2s ease-in-out;
-  -webkit-transition: opacity .2s ease-in-out;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.3s ease;
+  z-index: 1000;
 }
 
-.fade {
-  transition: opacity .2s ease-in-out;
-  -moz-transition: opacity .2s ease-in-out;
-  -webkit-transition: opacity .2s ease-in-out;
+.skip-link:focus {
+  transform: translate(-50%, 12px);
+  outline: 2px solid var(--accent);
 }
 
-span.highlight {
-  background-color: #ffffd0;
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-strong);
+  text-shadow: 0 0 12px rgba(96, 165, 250, 0.4);
+}
+
+p {
+  margin: 0 0 1rem;
+  color: var(--text);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  margin: 0 0 0.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #f8fafc;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: relative;
+  padding: 24px 0 80px;
+  overflow: hidden;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+  background: rgba(2, 6, 23, 0.75);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 10px 30px rgba(2, 6, 23, 0.35);
+}
+
+.nav-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  padding: 16px 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35), rgba(14, 165, 233, 0.4));
+  color: #e2e8f0;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  box-shadow: var(--shadow);
+}
+
+.site-nav {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.site-nav a {
+  padding: 8px 14px;
+  border-radius: 999px;
+  color: var(--text);
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid transparent;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.site-nav .nav-cta {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.55), rgba(56, 189, 248, 0.55));
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.hero {
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  margin-top: 60px;
+}
+
+.hero-text {
+  backdrop-filter: blur(16px);
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 40px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  margin-bottom: 0.75rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.6rem);
+  margin-bottom: 1rem;
+}
+
+.lead {
+  font-size: 1.1rem;
+  color: #cbd5f5;
+}
+
+.hero-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.tag {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.14);
+  color: #bfdbfe;
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+}
+
+.hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 1.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 14px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.85), rgba(56, 189, 248, 0.7));
+  color: #0f172a;
+  box-shadow: 0 10px 30px rgba(96, 165, 250, 0.25);
+}
+
+.button.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: none;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 40px rgba(96, 165, 250, 0.25);
+}
+
+.button.ghost:hover,
+.button.ghost:focus {
+  border-color: rgba(96, 165, 250, 0.7);
+  box-shadow: 0 12px 36px rgba(96, 165, 250, 0.18);
+}
+
+.current-work {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin-bottom: 0;
+}
+
+.hero-image figure {
+  margin: 0;
+  padding: 18px;
+  border-radius: 28px;
+  background: var(--surface-muted);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.hero-image img {
+  width: 100%;
+  border-radius: 28px;
+  display: block;
+  object-fit: cover;
+}
+
+.section {
+  padding: 80px 0;
+}
+
+.section.surface {
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.section-header {
+  margin-bottom: 32px;
+}
+
+.section-header p {
+  color: var(--text-muted);
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+}
+
+.news-timeline {
+  display: grid;
+  gap: 24px;
+}
+
+.news-item {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) 1fr;
+  gap: 24px;
+  padding: 24px;
+  border-radius: 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.news-item:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
+.news-date {
+  font-weight: 700;
+  color: #e0f2fe;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.badge {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.badge.award {
+  background: var(--badge-award);
+}
+
+.badge.publication {
+  background: var(--badge-paper);
+}
+
+.news-content h3 {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.news-content p {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.research-section {
+  display: grid;
+  gap: 32px;
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 40px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.research-content ul {
+  margin: 0 0 1.5rem 1.1rem;
+  color: var(--text);
+  padding: 0;
+}
+
+.research-content li {
+  margin-bottom: 0.75rem;
+}
+
+.publication-grid {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.publication-card {
+  background: var(--surface);
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.publication-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
+.publication-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+}
+
+.card-body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.paper-title {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #f8fafc;
+  margin: 0;
+}
+
+.authors {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.description {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.card-link {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.service-list {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.service-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.service-card p {
+  color: var(--text-muted);
+}
+
+.site-footer {
+  padding: 40px 0;
+  background: rgba(15, 23, 42, 0.5);
+  border-top: 1px solid var(--border);
+}
+
+.footer-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-muted);
+}
+
+.footer-links {
+  display: flex;
+  gap: 16px;
+}
+
+.footer-links a {
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .nav-wrapper {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .site-nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero {
+    margin-top: 36px;
+  }
+
+  .news-item {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-text,
+  .hero-image figure {
+    padding: 28px;
+  }
 }


### PR DESCRIPTION
## Summary
- add a sticky, glassmorphism navigation bar with a skip link and smooth scrolling for improved accessibility
- convert publication titles to semantic headings and refresh associated styling to fit the updated layout

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e563606f9483299c3bf863e50eb618